### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
+
 # signalfx-sleuth-zipkin-adapter
+
 An extension to Spring Cloud's spring-cloud-sleuth-zipkin library used to send 
 Zipkin formatted traces to the SignalFx Smart Agent or Smart Gateway.
 


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.